### PR TITLE
fix CMakeLists.txt issues and add ignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ SQLiteCpp_tests
 
 !FindSQLiteCpp.cmake
 /SQLiteCpp_Example
+
+.idea/
+cmake-build-debug/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(SQLiteCpp_Example ${SOURCE_FILES})
 if(UNIX AND NOT APPLE)
    # Linux
    target_link_libraries(SQLiteCpp_Example SQLiteCpp sqlite3 pthread dl)
-else(UNIX AND APPLE)
+elseif(UNIX AND APPLE)
    # Mac OS
    target_link_libraries(SQLiteCpp_Example SQLiteCpp sqlite3 pthread)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 2.8.12) # first version with add_compile_options()
+
+if (POLICY CMP0048)
+   cmake_policy(SET CMP0048 NEW)
+endif (POLICY CMP0048)
+
 project(SQLiteCpp_Example)
 
 # add SQLite3 C++ wrapper arround sqlite3 library (and sqlite3 itself provided for ease of use)


### PR DESCRIPTION
- fix(build):A duplicate ELSE command
- fix(build):Suppress cmake policy CMP0048 warning when building with cmake 3.x
- add ignore rule to compatible with macOS.